### PR TITLE
use normal file inside temp dir for scaler artifact

### DIFF
--- a/model_settlement/model_settlement/helpers.py
+++ b/model_settlement/model_settlement/helpers.py
@@ -656,14 +656,10 @@ def download_obj_from_s3(bucket_name, key, artifact_type):
         with tempfile.NamedTemporaryFile(suffix=".joblib") as fp:
             bucket.download_fileobj(key, fp)
             return joblib.load(fp.name)
-    # scaler doesn't seem, to work without saving and loading locally
     else:
-        with open("scaler.joblib", "wb") as file_data:
-            bucket.download_fileobj(key, file_data)
-        file_data.close()
-        return joblib.load("scaler.joblib")
-    #TODO: investigate why this throws an EOFError
-    # else:
-    #     with tempfile.NamedTemporaryFile(suffix=".joblib") as fp:
-    #         bucket.download_fileobj(key, fp)
-    #         return joblib.load(fp.name)
+        with tempfile.TemporaryDirectory() as dirpath:
+            #tempfile throws an EOFError for scaler. Use normal file inside temp directory
+            with open(f"{dirpath}/scaler.joblib", "wb") as file_data:
+                bucket.download_fileobj(key, file_data)
+            file_data.close()
+            return joblib.load(f"{dirpath}/scaler.joblib")

--- a/model_settlement/model_settlement/predict.py
+++ b/model_settlement/model_settlement/predict.py
@@ -114,8 +114,7 @@ def predict(**kwargs):
         :, ["Claim Identifier", "probability", "p_labels_corrected"]
     ].copy()
     payload_data.columns = ["claimNumber", "predictedProbability", "predictedValue"]
-    # removing the artifact that only works after downloading to local file system
-    os.remove("scaler.joblib")
+
 
     prediction_json = json.loads(payload_data.to_json(orient="records"))
     predicted_claim = prediction_json[0] if prediction_json else None

--- a/model_settlement/pyproject.toml
+++ b/model_settlement/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model_settlement"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model Settlement"
 authors = ["Teja <teja@spraoi.ai>"]
 maintainers = [


### PR DESCRIPTION
- use normal file inside temp dir for scaler artifact
- temp directory is used to make sure file is not created inside shared directory